### PR TITLE
feat - 카테고리 별 상품 목록 가져오기 api 구현 #10

### DIFF
--- a/src/main/java/com/example/capstone/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/capstone/apiPayload/ApiResponse.java
@@ -15,7 +15,7 @@ import lombok.Getter;
 public class ApiResponse<T> {
 
     @JsonProperty("isSuccess")
-    private final boolean isSuccess;
+    private final Boolean isSuccess;
     private final String code;
     private final String message;
     @JsonInclude(JsonInclude.Include.NON_NULL)  // null인 데이터는 제외한다.

--- a/src/main/java/com/example/capstone/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/capstone/apiPayload/code/status/ErrorStatus.java
@@ -45,7 +45,10 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_MISSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBERMISSION_400_1", "회원이 도전중인 미션을 찾을 수 없습니다."),
 
     // paging
-    PAGE_NUMBER_BAD_REQUEST(HttpStatus.BAD_REQUEST, "PAGENUMBER_400_1", "페이지 번호는 1 이상이어야 합니다.")
+    PAGE_NUMBER_BAD_REQUEST(HttpStatus.BAD_REQUEST, "PAGENUMBER_400_1", "페이지 번호는 1 이상이어야 합니다."),
+
+    // 카테고리
+    ITEM_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY_400_1", "상품 카테고리 id는 1 이상 ? 이하입니다.")
     ;
 
 

--- a/src/main/java/com/example/capstone/item/controller/ItemController.java
+++ b/src/main/java/com/example/capstone/item/controller/ItemController.java
@@ -19,9 +19,10 @@ public class ItemController {
     private final ItemService itemService;
 
     @GetMapping
-    public ApiResponse<List<ItemResponseDTO.Item>> getItemList(@Valid @Positive @RequestParam(name = "category-id") Long categoryId,
-                                                               @Min(1) @RequestParam(name = "page") Integer page,
-                                                               @Positive @RequestParam(name = "size") Integer size) {
-        return ApiResponse.onSuccess(itemService.getItemList(categoryId, page, size));
+    public ApiResponse<ItemResponseDTO.ItemList> getItemList(@Valid @Positive @RequestParam(name = "category-id") Long categoryId,
+                                                             @Min(1) @RequestParam(name = "page") Integer page,
+                                                             @Positive @RequestParam(name = "size") Integer size) {
+
+        return ApiResponse.onSuccess(itemService.getItemList(categoryId, page - 1, size));
     }
 }

--- a/src/main/java/com/example/capstone/item/controller/ItemController.java
+++ b/src/main/java/com/example/capstone/item/controller/ItemController.java
@@ -1,10 +1,27 @@
 package com.example.capstone.item.controller;
 
+import com.example.capstone.apiPayload.ApiResponse;
+import com.example.capstone.item.dto.ItemResponseDTO;
+import com.example.capstone.item.service.ItemService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/item")
 public class ItemController {
 
+    private final ItemService itemService;
+
+    @GetMapping
+    public ApiResponse<List<ItemResponseDTO.Item>> getItemList(@Valid @Positive @RequestParam(name = "category-id") Long categoryId,
+                                                               @Min(1) @RequestParam(name = "page") Integer page,
+                                                               @Positive @RequestParam(name = "size") Integer size) {
+        return ApiResponse.onSuccess(itemService.getItemList(categoryId, page, size));
+    }
 }

--- a/src/main/java/com/example/capstone/item/converter/ItemConverter.java
+++ b/src/main/java/com/example/capstone/item/converter/ItemConverter.java
@@ -16,15 +16,23 @@ public class ItemConverter {
                 .category(item.getCategory().getName())
                 .stock(item.getStock())
                 .price(item.getPrice())
-                .DiscountPrice(0)   // TODO: 할인 어떻게?
+                .discountPrice(0)   // TODO: 할인 어떻게?
                 .imageUrl(null)
                 .build();
     }
 
-    public static List<ItemResponseDTO.Item> toItemList (Page<Item> itemPage) {
-        return itemPage.stream()
+    public static ItemResponseDTO.ItemList toItemList (Page<Item> itemPage) {
+        List<ItemResponseDTO.Item> itemList = itemPage.stream()
                 .map(ItemConverter::toItemResponseDTO)
-                .collect(Collectors.toList());
-    }
+                .toList();
 
+        return ItemResponseDTO.ItemList.builder()
+                .listSize(itemPage.getSize())
+                .page(itemPage.getTotalPages())
+                .totalElement(itemPage.getTotalElements())
+                .isFirst(itemPage.isFirst())
+                .isLast(itemPage.isLast())
+                .itemList(itemList)
+                .build();
+    }
 }

--- a/src/main/java/com/example/capstone/item/converter/ItemConverter.java
+++ b/src/main/java/com/example/capstone/item/converter/ItemConverter.java
@@ -1,0 +1,30 @@
+package com.example.capstone.item.converter;
+
+import com.example.capstone.item.Item;
+import com.example.capstone.item.dto.ItemResponseDTO;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ItemConverter {
+
+    public static ItemResponseDTO.Item toItemResponseDTO(Item item) {
+        return ItemResponseDTO.Item.builder()
+                .id(item.getId())
+                .name(item.getName())
+                .category(item.getCategory().getName())
+                .stock(item.getStock())
+                .price(item.getPrice())
+                .DiscountPrice(0)   // TODO: 할인 어떻게?
+                .imageUrl(null)
+                .build();
+    }
+
+    public static List<ItemResponseDTO.Item> toItemList (Page<Item> itemPage) {
+        return itemPage.stream()
+                .map(ItemConverter::toItemResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/example/capstone/item/dto/ItemRequestDTO.java
+++ b/src/main/java/com/example/capstone/item/dto/ItemRequestDTO.java
@@ -1,0 +1,10 @@
+package com.example.capstone.item.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ItemRequestDTO {
+
+}

--- a/src/main/java/com/example/capstone/item/dto/ItemResponseDTO.java
+++ b/src/main/java/com/example/capstone/item/dto/ItemResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class ItemResponseDTO {
 
     @Builder
@@ -17,7 +19,20 @@ public class ItemResponseDTO {
         private String category;
         private Integer stock;
         private Integer price;
-        private Integer DiscountPrice;
+        private Integer discountPrice;
         private String imageUrl;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemList {
+        private Integer listSize;
+        private Integer page;
+        private Long totalElement;
+        private Boolean isFirst;
+        private Boolean isLast;
+        private List<Item> itemList;
     }
 }

--- a/src/main/java/com/example/capstone/item/dto/ItemResponseDTO.java
+++ b/src/main/java/com/example/capstone/item/dto/ItemResponseDTO.java
@@ -1,0 +1,23 @@
+package com.example.capstone.item.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ItemResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Item {
+        private Long id;
+        private String name;
+        private String category;
+        private Integer stock;
+        private Integer price;
+        private Integer DiscountPrice;
+        private String imageUrl;
+    }
+}

--- a/src/main/java/com/example/capstone/item/repository/CategoryRepository.java
+++ b/src/main/java/com/example/capstone/item/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package com.example.capstone.item.repository;
+
+import com.example.capstone.item.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/example/capstone/item/repository/ItemRepository.java
+++ b/src/main/java/com/example/capstone/item/repository/ItemRepository.java
@@ -1,10 +1,13 @@
 package com.example.capstone.item.repository;
 
+import com.example.capstone.item.Category;
 import com.example.capstone.item.Item;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
-
+    Page<Item>findByCategoryId(Long categoryId, Pageable pageable);
 }

--- a/src/main/java/com/example/capstone/item/service/ItemService.java
+++ b/src/main/java/com/example/capstone/item/service/ItemService.java
@@ -25,7 +25,7 @@ public class ItemService {
     private final ItemRepository itemRepository;
     private final CategoryRepository categoryRepository;
 
-    public List<ItemResponseDTO.Item> getItemList(Long categoryId, Integer page, Integer size) {
+    public ItemResponseDTO.ItemList getItemList(Long categoryId, Integer page, Integer size) {
         Category category = categoryValid(categoryId);
         Page<Item> itemPage = itemRepository.findByCategoryId(category.getId(), PageRequest.of(page, size));
         return ItemConverter.toItemList(itemPage);

--- a/src/main/java/com/example/capstone/item/service/ItemService.java
+++ b/src/main/java/com/example/capstone/item/service/ItemService.java
@@ -1,8 +1,38 @@
 package com.example.capstone.item.service;
 
+import com.example.capstone.apiPayload.code.status.ErrorStatus;
+import com.example.capstone.exception.GeneralException;
+import com.example.capstone.item.Category;
+import com.example.capstone.item.Item;
+import com.example.capstone.item.converter.ItemConverter;
+import com.example.capstone.item.dto.ItemResponseDTO;
+import com.example.capstone.item.repository.CategoryRepository;
+import com.example.capstone.item.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
 public class ItemService {
+    private final ItemRepository itemRepository;
+    private final CategoryRepository categoryRepository;
 
+    public List<ItemResponseDTO.Item> getItemList(Long categoryId, Integer page, Integer size) {
+        Category category = categoryValid(categoryId);
+        Page<Item> itemPage = itemRepository.findByCategoryId(category.getId(), PageRequest.of(page, size));
+        return ItemConverter.toItemList(itemPage);
+    }
+
+    private Category categoryValid(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_CATEGORY_NOT_FOUND));
+    }
 }

--- a/src/test/java/com/example/capstone/item/service/ItemServiceTest.java
+++ b/src/test/java/com/example/capstone/item/service/ItemServiceTest.java
@@ -6,20 +6,11 @@ import com.example.capstone.item.common.ItemType;
 import com.example.capstone.item.dto.ItemResponseDTO;
 import com.example.capstone.item.repository.CategoryRepository;
 import com.example.capstone.item.repository.ItemRepository;
-import com.example.capstone.member.Member;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.DefaultTransactionDefinition;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,9 +53,9 @@ class ItemServiceTest {
     void getItemListTest() {
         setUp();
 
-        List<ItemResponseDTO.Item> itemList = itemService.getItemList(category1.getId(), 0, 10);
+        ItemResponseDTO.ItemList itemList = itemService.getItemList(category1.getId(), 0, 10);
 
-        for (ItemResponseDTO.Item item : itemList) {
+        for (ItemResponseDTO.Item item : itemList.getItemList()) {
             assertThat(item.getCategory()).isEqualTo(category1.getName());
         }
     }

--- a/src/test/java/com/example/capstone/item/service/ItemServiceTest.java
+++ b/src/test/java/com/example/capstone/item/service/ItemServiceTest.java
@@ -1,0 +1,71 @@
+package com.example.capstone.item.service;
+
+import com.example.capstone.item.Category;
+import com.example.capstone.item.Item;
+import com.example.capstone.item.common.ItemType;
+import com.example.capstone.item.dto.ItemResponseDTO;
+import com.example.capstone.item.repository.CategoryRepository;
+import com.example.capstone.item.repository.ItemRepository;
+import com.example.capstone.member.Member;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class ItemServiceTest {
+
+    @Autowired
+    ItemService itemService;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    // TODO : 리팩토링 필요
+
+    void setUp() {
+        category1 = categoryRepository.saveAndFlush(new Category(1L, "과일"));
+        Category category2 = categoryRepository.saveAndFlush(new Category(2L, "야채"));
+
+        for (int i = 0; i < 10; i++) {
+            Item item = itemRepository.saveAndFlush(new Item((long) i, null, category1, ItemType.COMMON,
+                    "item" + i, "item 설명", 10000 + i, 3000 + i, 10 + i,
+                    "url", null, null, null));
+        }
+
+        for (int i = 10; i < 20; i++) {
+            Item item = itemRepository.saveAndFlush(new Item((long) i, null, category2, ItemType.COMMON,
+                    "item" + i, "item 설명", 10000 + i, 3000 + i, 10 + i,
+                    "url", null, null, null));
+        }
+    }
+
+    static Category category1;
+    @Test
+    @DisplayName("카테고리 별로 아이템 리스트를 가져온다.")
+    void getItemListTest() {
+        setUp();
+
+        List<ItemResponseDTO.Item> itemList = itemService.getItemList(category1.getId(), 0, 10);
+
+        for (ItemResponseDTO.Item item : itemList) {
+            assertThat(item.getCategory()).isEqualTo(category1.getName());
+        }
+    }
+}


### PR DESCRIPTION
- 카테고리 별 상품 목록 가져오기
- 테스트 코드 작성 (리팩토링 필요)

### 고민
- 커서 기반 페이지네이션으로 하기로 했는데, 보통 커서 기반 페이지네이션은 무한스크롤에 이용됨. 그렇다면 우리는 offset(페이지 번호)과 limit(페이지 사이즈) + 커서 기반 페이지네이션을 해야하는데 이 둘을 동시에 하는 방법이 있을까? 찾아봐야할 듯
- 테스트 코드가 지저분,, 어떻게 db에 영향을 안주고 테스트 코드를 작성할 수 있을까 (테스트용 db를 만드는 방법을 많이 사용하던데, 그렇게 되면 CI 할때는 어떻게 되는거지)
