### PR TITLE
[FIX] 마감임박 상품 조회시 취소된 주문상품은 제외되도록 수정

### DIFF
--- a/src/main/java/com/example/capstone/item/repository/ItemRepository.java
+++ b/src/main/java/com/example/capstone/item/repository/ItemRepository.java
@@ -14,13 +14,23 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
     Page<Item>findByCategoryId(Long categoryId, Pageable pageable);
 
     Page<Item> findAllBy(Pageable pageable);
-    @Query("select i from Item i where (i.stock - ((select sum(oi.quantity) from OrderItem oi where oi.item.id = i.id)) <= (i.stock * 0.1)) OR i.deadline < :seven ")
+    @Query("select i from Item i " +
+            "where (i.stock - ((select sum(oi.quantity) from OrderItem oi where oi.item.id = i.id and oi.order.status != com.example.capstone.order.common.OrderStatus.CANCELED )) <= (i.stock * 0.1)) " +
+            "OR i.deadline < :seven")
     Page<Item> searchImminentItem(LocalDateTime seven, Pageable pageable);
 
-    @Query("SELECT i FROM Item i LEFT JOIN OrderItem oi ON oi.item.id = i.id WHERE oi.createdAt BETWEEN :startDay AND :endDay GROUP BY i ORDER BY COUNT(oi) DESC")
+    @Query("SELECT i FROM Item i " +
+            "LEFT JOIN OrderItem oi ON oi.item.id = i.id " +
+            "WHERE oi.createdAt " +
+            "BETWEEN :startDay AND :endDay " +
+            "GROUP BY i " +
+            "ORDER BY COUNT(oi) DESC")
     Page<Item> searchPopularItem(LocalDateTime startDay, LocalDateTime endDay, Pageable pageable);
 
-    @Query("SELECT i FROM Item i JOIN Subscription sub ON i.member.id = sub.toMember.id where sub.fromMember.id = :fromMemberId ORDER BY i.createdAt DESC")
+    @Query("SELECT i FROM Item i " +
+            "JOIN Subscription sub ON i.member.id = sub.toMember.id " +
+            "where sub.fromMember.id = :fromMemberId " +
+            "ORDER BY i.createdAt DESC")
     Page<Item> searchSubscribedItem(Long fromMemberId , Pageable pageable);
 
     Page<Item>findByNameContaining(String keyword, Pageable pageable);

--- a/src/main/java/com/example/capstone/page/PageService.java
+++ b/src/main/java/com/example/capstone/page/PageService.java
@@ -33,7 +33,7 @@ public class PageService {
 
         return PageResponseDTO.Main.builder()
                 .numberUnreadAlarms(numberUnreadAlarms)
-                .numberItems(numberItems)
+                .numberItemsInCart(numberItems)
                 .imminentItemListPreview(imminentItemList.getItemList())
                 .popularItemListPreview(popularItemList.getItemList())
                 .subscribedItemListPreview(subscribedItemList.getItemList())


### PR DESCRIPTION
* 마감 임박 상품 조회 시 기준이 되는 재고에 취소된 주문 상품은 반영되지 않도록 수정했습니다.
* /item/page/pageService에서 발생되는 에러를 수정했습니다.
* itemRepository에 있는 쿼리를 조금 더 보기 좋게 수정했습니다.