### PR TITLE
[fix] order, order_item 속성 수정 #64

### DIFF
--- a/src/main/java/com/example/capstone/item/repository/ItemRepository.java
+++ b/src/main/java/com/example/capstone/item/repository/ItemRepository.java
@@ -16,7 +16,7 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
     Page<Item> findAllBy(Pageable pageable);
 
     @Query("select i from Item i " +
-            "where (i.stock - ((select sum(oi.quantity) from OrderItem oi where oi.item.id = i.id and oi.order.status != com.example.capstone.order.common.OrderStatus.CANCELED )) <= (i.stock * 0.1)) " +
+            "where (i.stock - ((select sum(oi.quantity) from OrderItem oi where oi.item.id = i.id and oi.status != com.example.capstone.order.common.OrderStatus.CANCELED )) <= (i.stock * 0.1)) " +
             "OR i.deadline < :seven")
     Page<Item> searchImminentItem(LocalDateTime seven, Pageable pageable);
 

--- a/src/main/java/com/example/capstone/order/Order.java
+++ b/src/main/java/com/example/capstone/order/Order.java
@@ -2,9 +2,7 @@ package com.example.capstone.order;
 
 import com.example.capstone.common.BaseEntity;
 import com.example.capstone.member.Member;
-import com.example.capstone.order.common.OrderStatus;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Entity
@@ -21,8 +19,4 @@ public class Order extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
-
-    @Enumerated(EnumType.STRING)
-    @NotNull
-    private OrderStatus status;
 }

--- a/src/main/java/com/example/capstone/order/OrderItem.java
+++ b/src/main/java/com/example/capstone/order/OrderItem.java
@@ -3,7 +3,6 @@ package com.example.capstone.order;
 import com.example.capstone.common.BaseEntity;
 import com.example.capstone.item.Item;
 import com.example.capstone.item.Review;
-import com.example.capstone.member.Member;
 import com.example.capstone.order.common.OrderStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
@@ -33,4 +32,8 @@ public class OrderItem extends BaseEntity {
 
     @OneToOne(mappedBy = "orderItem")
     private Review review;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private OrderStatus status;
 }

--- a/src/main/java/com/example/capstone/seller/converter/SellerManagementConverter.java
+++ b/src/main/java/com/example/capstone/seller/converter/SellerManagementConverter.java
@@ -21,7 +21,7 @@ public class SellerManagementConverter {
                 .consumerName(orderItem.getOrder().getMember().getName())
                 .price(item.getPrice())
                 .quantity(orderItem.getQuantity())
-                .status(orderItem.getOrder().getStatus())
+                .status(orderItem.getStatus())
                 .build();
     }
 

--- a/src/test/java/com/example/capstone/dummy/addDummyTest.java
+++ b/src/test/java/com/example/capstone/dummy/addDummyTest.java
@@ -116,7 +116,6 @@ public class addDummyTest {
             Order order = Order.builder()
                     .id((long)i)
                     .member(member)
-                    .status(OrderStatus.SHIPPING)
                     .build();
 
             OrderItem orderItem = OrderItem.builder()
@@ -124,6 +123,7 @@ public class addDummyTest {
                     .order(order)
                     .item(item)
                     .quantity(i)
+                    .status(OrderStatus.SHIPPING)
                     .build();
 
             Member member2 = Member.builder()

--- a/src/test/java/com/example/capstone/item/service/ItemServiceTest.java
+++ b/src/test/java/com/example/capstone/item/service/ItemServiceTest.java
@@ -4,7 +4,6 @@ import com.example.capstone.exception.GeneralException;
 import com.example.capstone.item.Category;
 import com.example.capstone.item.Item;
 import com.example.capstone.item.common.ItemType;
-import com.example.capstone.item.converter.ItemConverter;
 import com.example.capstone.item.dto.ItemResponseDTO;
 import com.example.capstone.item.repository.CategoryRepository;
 import com.example.capstone.item.repository.ItemRepository;
@@ -13,14 +12,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -91,40 +85,8 @@ class ItemServiceTest {
     @Transactional
     void getItemListFailureTest() {
         setUp();
-
         assertThrows(GeneralException.class,
-                () -> itemService.getItemList(category1.getId() + category2.getId(), 0, 10));
-    }
-
-    @Test
-    @DisplayName("QueryDsl Test - 마감 임박 상품 가져오기 테스트")
-    @Transactional
-    void QueryDslTest() {
-        LocalDateTime imminentDate = LocalDateTime.now().plusDays(7);
-        Pageable pageable = PageRequest.of(0, 6, Sort.by("createdAt").ascending());
-
-        List<Item> dslResult = itemRepository.findImminentItem();
-        Page<Item> jpqlResult = itemRepository.searchImminentItem(imminentDate, pageable);
-
-        List<ItemResponseDTO.Item> itemList = jpqlResult.stream()
-                .map(ItemConverter::toItemResponseDTO)
-                .toList();
-
-        for (int i = 0; i < jpqlResult.getSize(); i++) {
-            Item dslItem = dslResult.get(i);
-            ItemResponseDTO.Item jpqlItem = itemList.get(i);
-
-//            System.out.println("getId = " + dslItem.getId() + " " + jpqlItem.getId());
-//            System.out.println("getName = " + dslItem.getName() + " " + jpqlItem.getName());
-//            System.out.println("getDeadline = " + dslItem.getDeadline() + " " + jpqlItem.getDeadline());
-//            System.out.println("getPrice = " + dslItem.getPrice() + " " + jpqlItem.getPrice());
-//            System.out.println("getStock = " + dslItem.getStock() + " " + jpqlItem.getStock());
-//            System.out.println("getCategory = " + dslItem.getCategory() + " " + jpqlItem.getCategory());
-//            System.out.println();
-
-            assertThat(dslItem.getId()).isEqualTo(jpqlItem.getId());
-            assertThat(dslItem.getName()).isEqualTo(jpqlItem.getName());
-        }
+                () -> itemService.getItemList(Long.MAX_VALUE, 0, 10));
 
     }
 

--- a/src/test/java/com/example/capstone/order/repository/OrderItemRepositoryTest.java
+++ b/src/test/java/com/example/capstone/order/repository/OrderItemRepositoryTest.java
@@ -83,7 +83,6 @@ class OrderItemRepositoryTest {
         order = orderRepository.save(
                 Order.builder()
                         .member(consumer)
-                        .status(OrderStatus.PENDING)
                         .build()
         );
 
@@ -92,6 +91,7 @@ class OrderItemRepositoryTest {
                         .item(item)
                         .order(order)
                         .quantity(10)
+                        .status(OrderStatus.SHIPPING)
                         .build()
         );
     }


### PR DESCRIPTION
- Order에 orderStatus 삭제
- OrderItem에 orderStatus 추가

추가로
ItemRepository.searchImminentItem()의 jpql 쿼리를 수정하였습니다.
@Query("select i from Item i " +
            "where (i.stock - ((select sum(oi.quantity) from OrderItem oi where oi.item.id = i.id and **oi.status** != com.example.capstone.order.common.OrderStatus.CANCELED )) <= (i.stock * 0.1)) " +
            "OR i.deadline < :seven")


... oi.order.status ... -> ... oi.status ...