### PR TITLE
[FIX]Fix eb deploy fail #76

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Generate log files
         run: |
-          touch /var/log/custom.log
-          touch /var/log/err_log.log
+          touch ~/log/custom.log
+          touch ~/log/err_log.log
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,5 +11,5 @@ logging:
 
 log:
   config:
-    path: /var/log
+    path: ~/var/log
     filename: custom


### PR DESCRIPTION
로그파일 생성시, /var/log의 쓰기 권한이 없는 것 같아 홈 디렉터리에 생성합니다.