### PR TITLE
[FIX] CORS 문제를 해결하기 위해서 ./platform/nginx/nginx.conf을 수정 #109

### DIFF
--- a/.platform/nginx.conf
+++ b/.platform/nginx.conf
@@ -36,21 +36,20 @@ http {
 
       location / {
           proxy_pass          http://springboot;
-                  # CORS 관련 헤더 추가
-#            add_header 'Access-Control-Allow-Origin' '*';
-#            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
-#            add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type';
 
           if ($request_method = 'OPTIONS') {
-               add_header 'Access-Control-Allow-Origin' $allowed_origin always;
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
-               add_header 'Access-Control-Allow-Credentials' 'true';
-               return 204;
+                add_header 'Access-Control-Allow-Origin' '$allowed_origin';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, PATCH, OPTIONS';
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+                add_header 'Access-Control-Max-Age' 86400;
+                return 204;
           }
 
+          add_header 'Access-Control-Allow-Origin' '$allowed_origin' always;
+          add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+          add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;
           add_header 'Access-Control-Allow-Credentials' 'true';
-          add_header 'Access-Control-Allow-Origin' '*' always;
+
 
           proxy_http_version  1.1;
           proxy_set_header    Connection          $connection_upgrade;


### PR DESCRIPTION
로그인 시도시 상태 메시지를 응답 데이터를 조회할 수 없는 문제 해결하기 위해서 테스트 하던 중 CORS 허용이 nginx 설정을 통해 이루어지지 않는 문제 발견 

-> CORS 문제를 해결하기 위해서 ./platform/nginx/nginx.conf을 수정했습니다.           
Access-Control-Allow-Origin' 에 사전에 협의된 origin을 항상 추가하도록 하고 수정
