### PR TITLE
[Feat] 회원가입 기능 추가 #122

### DIFF
--- a/src/main/java/com/example/capstone/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/capstone/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,11 @@ public enum ErrorStatus implements BaseErrorCode {
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER_400_2", "닉네임은 필수 입니다."),
     MEMBER_ALREADY_SELLER(HttpStatus.BAD_REQUEST, "MEMBER_400_3", "해당 사용자는 이미 판매자입니다."),
     DUP_CHECK_FIELD_BADTYPE(HttpStatus.BAD_REQUEST, "MEMBER_400_4","중복 체크할 필드 타입이 잘못되었습니다."),
+    MALFORMED_MEMBER_LODINID(HttpStatus.BAD_REQUEST, "MEMBER_400_5", "ID 형식에 문제가 있습니다."),
+    MALFORMED_MEMBER_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER_400_6", "비밀번호 형식에 문제가 있습니다."),
+    MALFORMED_MEMBER_NAME(HttpStatus.BAD_REQUEST, "MEMBER_400_7", "사용자의 이름 형식에 문제가 있습니다."),
+    MALFORMED_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER_400_8", "사용자의 닉네임 형식에 문제가 있습니다."),
+    MALFORMED_MEMBER_PHONE(HttpStatus.BAD_REQUEST, "MEMBER_400_9", "사용자의 전화번호 형식에 문제가 있습니다."),
 
     // Seller
     SELLER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "SELLER_401_1", "해당 사용자는 판매자 권한이 없습니다."),

--- a/src/main/java/com/example/capstone/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/capstone/apiPayload/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER_400_1", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER_400_2", "닉네임은 필수 입니다."),
     MEMBER_ALREADY_SELLER(HttpStatus.BAD_REQUEST, "MEMBER_400_3", "해당 사용자는 이미 판매자입니다."),
+    DUP_CHECK_FIELD_BADTYPE(HttpStatus.BAD_REQUEST, "MEMBER_400_4","중복 체크할 필드 타입이 잘못되었습니다."),
 
     // Seller
     SELLER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "SELLER_401_1", "해당 사용자는 판매자 권한이 없습니다."),
@@ -60,10 +61,17 @@ public enum ErrorStatus implements BaseErrorCode {
     //Login
     ID_AND_PASSWORD_NOT_MATCH(HttpStatus.FORBIDDEN,"LOGIN_400_1","ID 또는 비밀번호가 잘못되었습니다."),
     LOGIN_DATA_NOT_ACCEPTED(HttpStatus.UNAUTHORIZED,"LOGIN_400_2","로그인 ID와 비밀번호가 비어있습니다."),
-    MALFORMED_LOGIN_DATA(HttpStatus.UNAUTHORIZED,"LOGIN_400_3","로그인 ID와 비밀번호을 전달하는 JSON 형식에 문제가 있습니다.")
-;
+    MALFORMED_LOGIN_DATA(HttpStatus.UNAUTHORIZED,"LOGIN_400_3","로그인 ID와 비밀번호을 전달하는 JSON 형식에 문제가 있습니다."),
 
-    ;
+    //signUp
+    DUPLICATED_LOGINID(HttpStatus.BAD_REQUEST,"DUPCHECK_400_1","중복된 로그인 ID입니다."),
+    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST,"DUPCHECK_400_2","중복된 닉네임입니다."),
+    NOT_CHECKED_LOGINID(HttpStatus.BAD_REQUEST,"DUPCHECK_400_3","중복 체크된 아이디가 아닙니다."),
+    NOT_CHECKED_NICKNAME(HttpStatus.BAD_REQUEST,"DUPCHECK_400_4","중복 체크된 닉네임이 아닙니다.")
+
+
+
+            ;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/capstone/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/capstone/apiPayload/code/status/SuccessStatus.java
@@ -16,11 +16,19 @@ public enum SuccessStatus implements BaseCode {
 
     //CART
     _OK_ADD_ITEM_IN_CART(HttpStatus.OK, "CART_200_1", "정상적으로 장바구니에 추가되었습니다."),
+
+    //POST
     _OK_GET_POST(HttpStatus.OK, "POST_200_1", "정상적으로 게시글이 조회되었습니다."),
     _OK_CREATE_POST(HttpStatus.OK, "POST_200_2", "정상적으로 게시글이 생성되었습니다."),
     _OK_UPDATE_POST(HttpStatus.OK, "POST_200_3", "정상적으로 게시글이 수정되었습니다."),
-    _OK_DELETE_POST(HttpStatus.OK, "POST_200_4", "정상적으로 게시글이 삭제되었습니다.")
-    ;
+    _OK_DELETE_POST(HttpStatus.OK, "POST_200_4", "정상적으로 게시글이 삭제되었습니다."),
+
+    //SINGUP
+    _OK_DUP_CHECK(HttpStatus.OK, "SIGNUP_200_1", "정상적으로 중복체크되었습니다."),
+    _OK_DELETE_TEMP_MEMBER(HttpStatus.OK,"DELETE_200_2","정상적으로 임시 멤버를 제거했습니다."),
+    _OK_SIGNUP(HttpStatus.OK,"DELETE_200_3","정상적으로 회원가입이 완료되었습니다.")
+
+            ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/capstone/member/Member.java
+++ b/src/main/java/com/example/capstone/member/Member.java
@@ -20,6 +20,12 @@ import java.util.List;
 @AllArgsConstructor
 @DynamicInsert
 @DynamicUpdate
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(name = "UniqueLoginId", columnNames = {"loginId"}),
+                @UniqueConstraint(name = "UniqueNickName", columnNames = {"nickName"})
+        }
+)
 public class Member extends BaseEntity {
 
     @Id

--- a/src/main/java/com/example/capstone/member/Member.java
+++ b/src/main/java/com/example/capstone/member/Member.java
@@ -70,4 +70,5 @@ public class Member extends BaseEntity {
     public void changeRole() {
         this.type = MemberType.ROLE_SELLER;
     }
+
 }

--- a/src/main/java/com/example/capstone/member/common/MemberValidator.java
+++ b/src/main/java/com/example/capstone/member/common/MemberValidator.java
@@ -1,0 +1,36 @@
+package com.example.capstone.member.common;
+
+public class MemberValidator {
+    public static Boolean validateLoginId(String loginId) {
+        String regex = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{4,14}$";
+
+        return loginId.matches(regex);
+    }
+
+    public static Boolean validatePassword(String password) {
+        String regex = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,14}$";
+
+        return password.matches(regex);
+    }
+
+    public static Boolean validatePhone(String phone) {
+
+        String regex = "^\\d{1,11}$";
+
+        return phone.matches(regex);
+    }
+
+    public static Boolean validateNickName(String nickName) {
+
+        String regex = "^(?=.*[A-Za-z가-힣])(?=.*\\d*[A-Za-z가-힣])[A-Za-z가-힣\\d]{4,14}$";
+
+        return nickName.matches(regex);
+    }
+
+    public static Boolean validateName(String name) {
+        String regex = "^[가-힣]{2,17}$";
+
+        return name.matches(regex);
+    }
+
+}

--- a/src/main/java/com/example/capstone/member/controller/MemberController.java
+++ b/src/main/java/com/example/capstone/member/controller/MemberController.java
@@ -1,21 +1,24 @@
 package com.example.capstone.member.controller;
 
 import com.example.capstone.apiPayload.ApiResponse;
+import com.example.capstone.apiPayload.code.status.ErrorStatus;
 import com.example.capstone.apiPayload.code.status.SuccessStatus;
+import com.example.capstone.exception.handler.ExceptionHandler;
+import com.example.capstone.member.dto.MemberRequestDTO;
 import com.example.capstone.member.dto.MemberResponseDTO;
-import com.example.capstone.member.service.MemberService;
+import com.example.capstone.member.service.MemberServiceImpl;
 import com.example.capstone.security.dto.MemberSecurityDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 public class MemberController {
-    private final MemberService memberService;
+    private final MemberServiceImpl memberService;
 
     @PatchMapping("/auth/member/to-seller")
     public ApiResponse<MemberResponseDTO.MemberState> changeMemberRole(@AuthenticationPrincipal MemberSecurityDTO member) {
@@ -23,4 +26,51 @@ public class MemberController {
         MemberResponseDTO.MemberState response = memberService.changeMemberRole(memberId);
         return ApiResponse.of(SuccessStatus._OK_CHANGE_ROLE, response);
     }
+
+    @PostMapping("/member/dupCheck")
+    public ApiResponse<MemberResponseDTO.DupCheckField> dupCheck(@Valid @RequestBody MemberRequestDTO.DupCheckField dupCheckFields) {
+
+            log.info("dupCheck controller start ...............");
+
+
+        if(!dupCheckFields.getType().equals("loginId") && !dupCheckFields.getType().equals("nickName") ){
+
+            throw new ExceptionHandler(ErrorStatus.DUP_CHECK_FIELD_BADTYPE);
+        }
+
+        MemberResponseDTO.DupCheckField dupCheckField = memberService.checkField(dupCheckFields);
+
+        log.info("dupCheck success...............");
+
+        return ApiResponse.of(SuccessStatus._OK_DUP_CHECK,dupCheckField);
+
+    }
+
+    @DeleteMapping("/member/{memberId}")
+    public ApiResponse<String> deleteTempMember(@PathVariable Long memberId) {
+
+        log.info("deleteTempMember controller start ...............");
+
+        memberService.deleteTempMember(memberId);
+
+        log.info("deleteTempMember success...............");
+
+        return ApiResponse.of(SuccessStatus._OK_DELETE_TEMP_MEMBER,null);
+
+    }
+
+    @PostMapping("/member/signUp")
+    public ApiResponse<MemberResponseDTO.SignUpMember> signUp(@Valid @RequestBody MemberRequestDTO.SignUpMember signUpMember) {
+
+        log.info("signUp controller start ...............");
+
+        MemberResponseDTO.SignUpMember member = memberService.signUp(signUpMember);
+
+
+        log.info("signUp success...............");
+
+        return ApiResponse.of(SuccessStatus._OK_SIGNUP,member);
+
+    }
+
 }

--- a/src/main/java/com/example/capstone/member/controller/MemberController.java
+++ b/src/main/java/com/example/capstone/member/controller/MemberController.java
@@ -14,6 +14,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.example.capstone.member.common.MemberValidator.validateLoginId;
+import static com.example.capstone.member.common.MemberValidator.validateNickName;
+
 @RestController
 @RequiredArgsConstructor
 @Slf4j
@@ -37,6 +40,8 @@ public class MemberController {
 
             throw new ExceptionHandler(ErrorStatus.DUP_CHECK_FIELD_BADTYPE);
         }
+
+        validateMember(dupCheckFields);
 
         MemberResponseDTO.DupCheckField dupCheckField = memberService.checkField(dupCheckFields);
 
@@ -71,6 +76,14 @@ public class MemberController {
 
         return ApiResponse.of(SuccessStatus._OK_SIGNUP,member);
 
+    }
+
+    void validateMember(MemberRequestDTO.DupCheckField dupCheckFields){
+        if (!dupCheckFields.getLoginId().isEmpty() && !validateLoginId(dupCheckFields.getLoginId()))
+            throw new ExceptionHandler(ErrorStatus.MALFORMED_MEMBER_LODINID);
+
+        if(!dupCheckFields.getNickName().isEmpty() && !validateNickName(dupCheckFields.getNickName()))
+            throw new ExceptionHandler(ErrorStatus.MALFORMED_MEMBER_NICKNAME);
     }
 
 }

--- a/src/main/java/com/example/capstone/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/capstone/member/converter/MemberConverter.java
@@ -1,7 +1,10 @@
 package com.example.capstone.member.converter;
 
 
+import com.example.capstone.member.Address;
 import com.example.capstone.member.Member;
+import com.example.capstone.member.dto.AddressDTO;
+import com.example.capstone.member.dto.MemberRequestDTO;
 import com.example.capstone.member.dto.MemberResponseDTO;
 import com.example.capstone.seller.converter.SellerConverter;
 
@@ -11,6 +14,7 @@ import static com.example.capstone.seller.converter.SellerConverter.toSellerResp
 
 
 public class MemberConverter {
+
 
     public static MemberResponseDTO.MemberState toMemberState(Member member) {
         return MemberResponseDTO.MemberState.builder()
@@ -32,6 +36,25 @@ public class MemberConverter {
                 .seller(Optional.ofNullable(member.getSeller())
                         .map(SellerConverter::toSellerResponseDTO)
                         .orElse(null))
+                .build();
+    }
+
+    public static Member toSignUpMember(MemberRequestDTO.SignUpMember signUpMember, String encodedPassword) {
+        return Member.builder()
+                .id(signUpMember.getId())
+                .loginId(signUpMember.getLoginId())
+                .password(encodedPassword)
+                .name(signUpMember.getName())
+                .nickName(signUpMember.getNickName())
+                .phone(signUpMember.getPhone())
+                .build();
+    }
+
+    public static Address toAddress(AddressDTO.Address address) {
+        return Address.builder()
+                .member(address.getMember())
+                .address(address.getAddress())
+                .details(address.getDetails())
                 .build();
     }
 

--- a/src/main/java/com/example/capstone/member/dto/AddressDTO.java
+++ b/src/main/java/com/example/capstone/member/dto/AddressDTO.java
@@ -1,0 +1,25 @@
+package com.example.capstone.member.dto;
+
+import com.example.capstone.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AddressDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Address {
+
+
+        private Member member;
+
+        private String address;
+
+        private String details;
+
+    }
+}

--- a/src/main/java/com/example/capstone/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/example/capstone/member/dto/MemberRequestDTO.java
@@ -1,0 +1,47 @@
+package com.example.capstone.member.dto;
+
+import lombok.*;
+
+public class MemberRequestDTO {
+
+    /**
+     * checkType은 loginId와 nickName 중 중복 체크할 항목을 나타냅니다.
+     */
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DupCheckField {
+
+        private String type;
+
+        private String loginId;
+
+        private String nickName;
+
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SignUpMember{
+
+        private Long id;
+
+        private String loginId;
+
+        private String password;
+
+        private String name;
+
+        private String nickName;
+
+        private String phone;
+
+        private String address;
+
+        private String details;
+    }
+
+}

--- a/src/main/java/com/example/capstone/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/capstone/member/dto/MemberResponseDTO.java
@@ -48,5 +48,43 @@ public class MemberResponseDTO {
         private MemberType memberType;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DupCheckField {
+
+        private Long id;
+
+        private String type;
+
+        private String loginId;
+
+        private String nickName;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SignUpMember{
+
+        private Long id;
+
+        private String loginId;
+
+        private String password;
+
+        private String name;
+
+        private String nickName;
+
+        private String phone;
+
+        private String address;
+
+        private String details;
+    }
+
 
 }

--- a/src/main/java/com/example/capstone/member/repository/AddressRepository.java
+++ b/src/main/java/com/example/capstone/member/repository/AddressRepository.java
@@ -1,0 +1,7 @@
+package com.example.capstone.member.repository;
+
+import com.example.capstone.member.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+}

--- a/src/main/java/com/example/capstone/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/capstone/member/repository/MemberRepository.java
@@ -11,4 +11,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findMemberByLoginId(String username);
 
+    Optional<Member> findMemberByNickName(String nickName);
+
+    void deleteMemberByLoginId(String loginId);
+
+    void deleteMemberByNickName(String nickName);
+
 }

--- a/src/main/java/com/example/capstone/member/service/MemberService.java
+++ b/src/main/java/com/example/capstone/member/service/MemberService.java
@@ -1,43 +1,18 @@
 package com.example.capstone.member.service;
 
-import com.example.capstone.apiPayload.code.status.ErrorStatus;
-import com.example.capstone.common.QueryService;
-import com.example.capstone.exception.GeneralException;
-import com.example.capstone.member.Member;
-import com.example.capstone.member.common.MemberType;
-import com.example.capstone.member.converter.MemberConverter;
+import com.example.capstone.member.dto.MemberRequestDTO;
 import com.example.capstone.member.dto.MemberResponseDTO;
-import com.example.capstone.member.repository.MemberRepository;
-import com.example.capstone.seller.Seller;
-import com.example.capstone.seller.repository.SellerRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-@Slf4j
-public class MemberService {
-    private final MemberRepository memberRepository;
-    private final SellerRepository sellerRepository;
-    private final QueryService queryService;
+public interface MemberService {
 
-    public MemberResponseDTO.MemberState changeMemberRole(Long memberId) {
-        Member member = queryService.findMember(memberId);
+    MemberResponseDTO.MemberState changeMemberRole(Long memberId);
 
-        if (member.getType() == MemberType.ROLE_SELLER) {
-            throw new GeneralException(ErrorStatus.MEMBER_ALREADY_SELLER);
-        }
+    MemberResponseDTO.DupCheckField checkField(MemberRequestDTO.DupCheckField dupCheckFields);
 
-        member.changeRole();
-        memberRepository.save(member);
+    void deleteTempMember (Long memberId);
 
-        Seller seller = Seller.builder()
-                .member(member)
-                .build();
+    MemberResponseDTO.SignUpMember signUp (MemberRequestDTO.SignUpMember signUpMember);
 
-        sellerRepository.save(seller);
 
-        return MemberConverter.toMemberState(member);
+
     }
-}

--- a/src/main/java/com/example/capstone/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/capstone/member/service/MemberServiceImpl.java
@@ -1,0 +1,210 @@
+package com.example.capstone.member.service;
+
+import com.example.capstone.apiPayload.code.status.ErrorStatus;
+import com.example.capstone.common.QueryService;
+import com.example.capstone.exception.GeneralException;
+import com.example.capstone.exception.handler.ExceptionHandler;
+import com.example.capstone.member.Address;
+import com.example.capstone.member.Member;
+import com.example.capstone.member.common.MemberType;
+import com.example.capstone.member.converter.MemberConverter;
+import com.example.capstone.member.dto.AddressDTO;
+import com.example.capstone.member.dto.MemberRequestDTO;
+import com.example.capstone.member.dto.MemberResponseDTO;
+import com.example.capstone.member.repository.AddressRepository;
+import com.example.capstone.member.repository.MemberRepository;
+import com.example.capstone.seller.Seller;
+import com.example.capstone.seller.repository.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.example.capstone.member.converter.MemberConverter.toAddress;
+import static com.example.capstone.member.converter.MemberConverter.toSignUpMember;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final SellerRepository sellerRepository;
+    private final QueryService queryService;
+    private final PasswordEncoder passwordEncoder;
+    private final AddressRepository addressRepository;
+
+    public MemberResponseDTO.MemberState changeMemberRole(Long memberId) {
+        Member member = queryService.findMember(memberId);
+
+        if (member.getType() == MemberType.ROLE_SELLER) {
+            throw new GeneralException(ErrorStatus.MEMBER_ALREADY_SELLER);
+        }
+
+        member.changeRole();
+        memberRepository.save(member);
+
+        Seller seller = Seller.builder()
+                .member(member)
+                .build();
+
+        sellerRepository.save(seller);
+
+        return MemberConverter.toMemberState(member);
+    }
+
+    @Override
+    public MemberResponseDTO.DupCheckField checkField (MemberRequestDTO.DupCheckField dupCheckFields) {
+
+        log.info("DupCheck service start............");
+        Member member=null;
+
+        if (dupCheckFields.getType().equals("loginId")){
+
+            member = checkLoginId(dupCheckFields);
+
+        } else if(dupCheckFields.getType().equals("nickName")) {
+
+            member = checkNickName(dupCheckFields);
+
+        } else
+            throw new ExceptionHandler(ErrorStatus.MEMBER_NOT_FOUND);
+
+        Member savedMember = memberRepository.save(member);
+        log.info("DupCheck service end............");
+
+        return MemberResponseDTO.DupCheckField.builder()
+                .id(savedMember.getId())
+                .type(dupCheckFields.getType())
+                .loginId(savedMember.getLoginId())
+                .nickName(savedMember.getNickName())
+                .build();
+    }
+
+    @Override
+    public void deleteTempMember (Long memberId) {
+
+        log.info("deleteTempMember service start............");
+
+        memberRepository.deleteById(memberId);
+
+        log.info("deleteTempMember service end............");
+
+    }
+
+    @Override
+    public MemberResponseDTO.SignUpMember signUp (MemberRequestDTO.SignUpMember signUpMember) {
+
+        log.info("signUp service start............");
+
+        Member tempMember = memberRepository.findById(signUpMember.getId())
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (!tempMember.getLoginId().equals(signUpMember.getLoginId())){
+
+            throw new ExceptionHandler(ErrorStatus.NOT_CHECKED_LOGINID);
+
+        } else if(!tempMember.getNickName().equals(signUpMember.getNickName())){
+
+            throw new ExceptionHandler(ErrorStatus.NOT_CHECKED_NICKNAME);
+        }
+
+        String encodedPassword = passwordEncoder.encode(signUpMember.getPassword());
+
+        Member savedMember = memberRepository.save(toSignUpMember(signUpMember,encodedPassword));
+
+        AddressDTO.Address address = AddressDTO.Address.builder()
+                .member(savedMember)
+                .address(signUpMember.getAddress())
+                .details(signUpMember.getDetails())
+                .build();
+
+        Address savedAddress = addressRepository.save(toAddress(address));
+
+        log.info("signUp service end............");
+
+        return MemberResponseDTO.SignUpMember.builder()
+                .id(savedMember.getId())
+                .loginId(savedMember.getLoginId())
+                .password(savedMember.getPassword())
+                .name(savedMember.getName())
+                .nickName(savedMember.getNickName())
+                .phone(savedMember.getPhone())
+                .address(savedAddress.getAddress())
+                .details(savedAddress.getDetails())
+                .build();
+
+    }
+
+
+
+    private Member checkLoginId (MemberRequestDTO.DupCheckField dupCheckField) {
+
+        Optional<Member> memberByLoginId = memberRepository.findMemberByLoginId(dupCheckField.getLoginId());
+
+        //중복된 로그인 ID가 존재하지 않을 때
+        if(memberByLoginId.isEmpty()){
+
+            return getMemberByNickName(dupCheckField);
+
+        //중복된 로그인 ID가 존재할 때
+        } else
+            throw new ExceptionHandler(ErrorStatus.DUPLICATED_LOGINID);
+    }
+
+    private Member checkNickName (MemberRequestDTO.DupCheckField dupCheckField){
+
+        Optional<Member> memberByNickName = memberRepository.findMemberByNickName(dupCheckField.getNickName());
+
+        //중복된 닉네임이 존재하지 않을 때
+        if(memberByNickName.isEmpty()){
+
+            return getMemberByLoginId(dupCheckField);
+
+            //중복된 닉네임이 존재할 때
+        } else
+            throw new ExceptionHandler(ErrorStatus.DUPLICATED_NICKNAME);
+
+    }
+
+    private Member getMemberByNickName(MemberRequestDTO.DupCheckField dupCheckField){
+        if(dupCheckField.getNickName().isEmpty())
+            return Member.builder()
+                    .loginId(dupCheckField.getLoginId())
+                    .build();
+
+        Member searchedMember = memberRepository.findMemberByNickName(dupCheckField.getNickName())
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return Member.builder()
+                .id(searchedMember.getId())
+                .loginId(dupCheckField.getLoginId())
+                .nickName(searchedMember.getNickName())
+                .build();
+    }
+
+    private Member getMemberByLoginId(MemberRequestDTO.DupCheckField dupCheckField){
+
+        if(dupCheckField.getLoginId().isEmpty())
+            return Member.builder()
+                    .nickName(dupCheckField.getNickName())
+                    .build();
+
+        Member searchedMember = memberRepository.findMemberByLoginId(dupCheckField.getLoginId())
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return Member.builder()
+                .id(searchedMember.getId())
+                .loginId(searchedMember.getLoginId())
+                .nickName(dupCheckField.getNickName())
+                .build();
+
+    }
+
+
+}

--- a/src/main/java/com/example/capstone/order/controller/CartController.java
+++ b/src/main/java/com/example/capstone/order/controller/CartController.java
@@ -44,6 +44,6 @@ public class CartController {
         cartServiceImpl.saveItemInCart(requestedCart);
         log.info("saveItemInCart success.........");
 
-        return ApiResponse.of(SuccessStatus._OK_SUBSCRIBE, "장바구니에 담기 완료");
+        return ApiResponse.of(SuccessStatus._OK_ADD_ITEM_IN_CART, null);
     }
 }

--- a/src/main/java/com/example/capstone/order/controller/CartController.java
+++ b/src/main/java/com/example/capstone/order/controller/CartController.java
@@ -2,6 +2,7 @@ package com.example.capstone.order.controller;
 
 import com.example.capstone.apiPayload.ApiResponse;
 import com.example.capstone.apiPayload.code.status.SuccessStatus;
+import com.example.capstone.order.Cart;
 import com.example.capstone.order.dto.CartRequestDTO;
 import com.example.capstone.order.service.CartService;
 import com.example.capstone.order.service.CartServiceImpl;

--- a/src/main/java/com/example/capstone/order/dto/CartResponseDTO.java
+++ b/src/main/java/com/example/capstone/order/dto/CartResponseDTO.java
@@ -1,0 +1,29 @@
+package com.example.capstone.order.dto;
+
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class CartResponseDTO {
+
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class cart {
+
+        private Long id;
+
+        private Long itemId;
+
+        private Long memberId;
+
+        private Integer quantity;
+
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,7 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
   profiles:
-    active: prod
+    active: ${ACTIVE_PROFILE}
   jackson:
     time-zone: Asia/Seoul
   jwt:

--- a/src/test/java/com/example/capstone/dummy/addDummyTest.java
+++ b/src/test/java/com/example/capstone/dummy/addDummyTest.java
@@ -39,6 +39,7 @@ import java.time.LocalDateTime;
 
 @SpringBootTest
 public class addDummyTest {
+
     @Autowired
     private PasswordEncoder passwordEncoder;
 

--- a/src/test/java/com/example/capstone/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/capstone/member/service/MemberServiceTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 class MemberServiceTest {
 
     @InjectMocks
-    MemberService memberService;
+    MemberServiceImpl memberService;
 
     @Mock
     QueryService queryService;

--- a/src/test/java/com/example/capstone/member/util/MemberValidatorTest.java
+++ b/src/test/java/com/example/capstone/member/util/MemberValidatorTest.java
@@ -1,0 +1,91 @@
+package com.example.capstone.member.util;
+
+
+import com.example.capstone.member.common.MemberValidator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static com.example.capstone.member.common.MemberValidator.*;
+
+public class MemberValidatorTest {
+
+    @Test
+    @DisplayName("로그인ID 체크 테스트")
+    void testLoginId(){
+        String[] failCase = {"test", "328543", "3한글543", "t1"};
+
+        String successCase ="test543";
+
+        for (String s : failCase) {
+            Assertions.assertThat(validateLoginId(s)).isFalse();
+        }
+
+        Assertions.assertThat(validateLoginId(successCase)).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("비밀번호 체크 테스트")
+    void testPassword(){
+
+        String[] failCase = {"test", "328543", "3한글543", "t1","sjse98ㄱ","sghwu4egow9he4gw4g"};
+
+        String successCase ="test5d43";
+
+        for (String s : failCase) {
+            Assertions.assertThat(validatePassword(s)).isFalse();
+        }
+
+        Assertions.assertThat(validatePassword(successCase)).isTrue();
+    }
+
+    @Test
+    @DisplayName("핸드폰 번호 체크 테스트")
+    void testPhone(){
+        String[] failCase = {"test", "3한글543", "t1","sjse98ㄱ","sghwu4egow9he4gw4g"};
+
+        String successCase ="34098093498";
+
+        for (String s : failCase) {
+            Assertions.assertThat(validatePhone(s)).isFalse();
+        }
+
+        Assertions.assertThat(validatePhone(successCase)).isTrue();
+    }
+
+    @Test
+    @DisplayName("닉네임 체크 테스트")
+    void testNickName(){
+        String[] failCase = {"tst", "3한글54tjoie4jgojrgjw43", "ㅇㄹㅎㄱ호4","sjse98ㄱ","sghwu4egow9he4gw4g"};
+
+        String successCase ="3한글543";
+
+        for (String s : failCase) {
+            Assertions.assertThat(validateNickName(s)).isFalse();
+        }
+
+        Assertions.assertThat(validateNickName(successCase)).isTrue();
+    }
+
+    @Test
+    @DisplayName("이름 체크 테스트")
+    void testName(){
+        String[] failCase = {"3한글543","tst", "3한글54tjoie4jgojrgjw43", "ㅇㄹㅎㄱ호4","sjse98ㄱ","sghwu4egow9he4gw4g"};
+
+        String successCase ="한글";
+
+        for (String s : failCase) {
+            Assertions.assertThat(validateName(s)).isFalse();
+        }
+
+        Assertions.assertThat(validateName(successCase)).isTrue();
+    }
+
+
+
+
+
+}


### PR DESCRIPTION
- 회원 가입전에 닉네임과 아이디의 중복 검사를 할 수 있는 API를 추가했습니다.
- 사용자가 입력한 데이터가 알맞은 형식인지 확인할 수 있는 MemberValidator를 추가했습니다.
- 사용자가 저장한 임시 멤버를 삭제할 수 있는 API를 추가했습니다.
- 회원 가입을 할 수 있는 API를 추가했습니다.