### PR TITLE
[FIX] 요청 바디 사이즈 제한을 200M으로 설정 #150

### DIFF
--- a/.platform/nginx/conf.d/client_max_body_size.conf
+++ b/.platform/nginx/conf.d/client_max_body_size.conf
@@ -1,0 +1,1 @@
+client_max_body_size 200M;


### PR DESCRIPTION
- nginx 설정에서 요청 바디 사이즈 제한을 200MB로 업그레이드 했습니다.