### PR TITLE
[FIX] 이미지의 상세정보에서 첫번째 대표이미지는 건너 뛰기 #150

### DIFF
--- a/src/main/java/com/example/capstone/item/converter/ItemImageConverter.java
+++ b/src/main/java/com/example/capstone/item/converter/ItemImageConverter.java
@@ -19,6 +19,9 @@ public class ItemImageConverter {
     }
 
     public static List<ItemImageResponseDTO.ItemImage> toItemImageList (List<ItemImage> itemImages) {
+        //대표 이미지는 건너 뛰고 건네주기
+        itemImages.remove(0);
+
         return itemImages.stream()
                 .map(ItemImageConverter::toItemImageDTO)
                 .toList();


### PR DESCRIPTION
이미지의 상세정보에서 첫번째 대표이미지는 건너 뛰고 다음 이미지들을 전송합니다.