### PR TITLE
[FIX] 장바구니의 insert시 중복 체크 #150

### DIFF
--- a/src/main/java/com/example/capstone/order/Cart.java
+++ b/src/main/java/com/example/capstone/order/Cart.java
@@ -28,4 +28,8 @@ public class Cart {
 
     @Min(1)
     private Integer quantity;
+
+    public void changeQuantity(Integer quantity){
+        this.quantity = quantity;
+    }
 }

--- a/src/main/java/com/example/capstone/order/repository/CartRepository.java
+++ b/src/main/java/com/example/capstone/order/repository/CartRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
@@ -19,5 +20,7 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
             "where c.member.id = :memberId ")
     List<Cart> searchItemInCart(Long memberId);
 
+    @Query("select c from Cart c where c.item.id = :itemId and c.member.id = :memberId")
+    Optional<Cart> searchCartByMemberAndItem(Long itemId, Long memberId);
 
 }


### PR DESCRIPTION
- 장바구니에 물건을 담을 때 멤버와 아이템을 기준으로 조회한 다음 같은 장바구니 항목이 존재한다면 양만 바꿔 삽입하도록 수정